### PR TITLE
Add stricter card recognition

### DIFF
--- a/Helper/GiftCardHelper.php
+++ b/Helper/GiftCardHelper.php
@@ -12,6 +12,8 @@ use Magento\SalesRule\Model\RuleFactory;
 
 class GiftCardHelper
 {
+    const GIFT_CARD_STRING_LENGTH = 16;
+
     /**
      * @var GiftyClient
      */
@@ -55,7 +57,7 @@ class GiftCardHelper
     {
         $this->logger->debug('GiftCardHelper getGiftCard: ' . $code);
 
-        if (isset($this->giftCards[$code]) === false) {
+        if (property_exists((object) $this->giftCards, $code) === false) {
             $this->logger->debug('Fetching Gift Card from API: ' . $code);
 
             try {

--- a/Observer/OrderFailureTransactionRelease.php
+++ b/Observer/OrderFailureTransactionRelease.php
@@ -69,7 +69,7 @@ class OrderFailureTransactionRelease implements ObserverInterface
         }
 
         if ($giftCard === null || $transaction === null) {
-            $this->giftyHelper->logger->debug(__(
+            $this->giftyHelper->logger->critical(__(
                 "Failed to release transaction on Gift Card \"%1\". Transaction ID: \"%2\". Order ID: \"%3\".",
                 $order->getGiftyGiftCardCode(),
                 $order->getGiftyTransactionIdRedeem(),

--- a/Plugin/Sales/TransactionRelease.php
+++ b/Plugin/Sales/TransactionRelease.php
@@ -36,8 +36,6 @@ class TransactionRelease
 
     public function afterCancel(OrderService $subject, bool $result, $orderId): bool
     {
-        $this->giftyHelper->logger->debug('afterCancel!');
-
         if (!$result) {
             return $result;
         }
@@ -47,6 +45,8 @@ class TransactionRelease
         if ($order->getGiftyTransactionIdRedeem() === null) {
             return $result;
         }
+
+        $this->giftyHelper->logger->debug('afterCancel');
 
         $giftCard = $this->giftCardHelper->getGiftCard($order->getGiftyGiftCardCode());
         $transaction = null;

--- a/Plugin/SalesRule/CouponModelLoad.php
+++ b/Plugin/SalesRule/CouponModelLoad.php
@@ -41,9 +41,15 @@ class CouponModelLoad
     {
         if ($result->getCouponId() === null &&
             $field === 'code' &&
-            $modelId !== null
+            $modelId !== null &&
+            strlen($modelId) >= GiftCardHelper::GIFT_CARD_STRING_LENGTH
         ) {
             $code = $this->giftyHelper->sanitizeCouponInput($modelId);
+
+            if(strlen($code) !== GiftCardHelper::GIFT_CARD_STRING_LENGTH) {
+                return $result;
+            }
+
             $giftCard = $this->giftCardHelper->getGiftCard($code);
 
             if ($giftCard !== null && $giftCard->isRedeemable()) {

--- a/Plugin/SalesRule/CouponUsage.php
+++ b/Plugin/SalesRule/CouponUsage.php
@@ -42,13 +42,18 @@ class CouponUsage
         $couponId,
         $increment = true
     ): ?array {
-        $this->giftyHelper->logger->debug('CouponUsage beforeUpdateCustomerCouponTimesUsed logger');
-
-        if ($couponId === '' || $couponId === null) {
+        if ($couponId === '' || $couponId === null || strlen($couponId) < GiftCardHelper::GIFT_CARD_STRING_LENGTH) {
             return null;
         }
 
+        $this->giftyHelper->logger->debug('CouponUsage beforeUpdateCustomerCouponTimesUsed');
+
         $code = $this->giftyHelper->sanitizeCouponInput($couponId);
+
+        if(strlen($code) !== GiftCardHelper::GIFT_CARD_STRING_LENGTH) {
+            return null;
+        }
+
         $giftCard = $this->giftCardHelper->getGiftCard($code);
         $increment = false;
 

--- a/Plugin/SalesRule/RuleCollection.php
+++ b/Plugin/SalesRule/RuleCollection.php
@@ -58,13 +58,17 @@ class RuleCollection
         $now = null,
         Address $address = null
     ) {
-        $this->giftyHelper->logger->debug('RuleCollection beforeSetValidationFilter logger');
-
-        if ($couponCode === '' || $couponCode === null) {
+        if ($couponCode === '' || $couponCode === null || strlen($couponCode) < GiftCardHelper::GIFT_CARD_STRING_LENGTH) {
             return null;
         }
 
-        $this->couponCode = $this->giftyHelper->sanitizeCouponInput($couponCode);
+        $couponCode = $this->giftyHelper->sanitizeCouponInput($couponCode);
+
+        if(strlen($couponCode) === GiftCardHelper::GIFT_CARD_STRING_LENGTH) {
+            $this->giftyHelper->logger->debug('RuleCollection beforeSetValidationFilter');
+
+            $this->couponCode = $couponCode;
+        }
 
         return null;
     }
@@ -76,6 +80,8 @@ class RuleCollection
         ) {
             return $result;
         }
+
+        $this->giftyHelper->logger->debug('RuleCollection afterLoad');
 
         $giftCard = $this->giftCardHelper->getGiftCard($this->couponCode);
 

--- a/Plugin/SalesRule/RuleModelLoad.php
+++ b/Plugin/SalesRule/RuleModelLoad.php
@@ -27,13 +27,19 @@ class RuleModelLoad
 
     public function afterLoad(Rule $rule, Rule $result, $ruleId, $field = null): Rule
     {
-        $this->giftyHelper->logger->debug('RuleModelLoad afterLoad logger');
-
         if ($result->getCouponCode() === null &&
             $field === null &&
-            $ruleId !== null
+            $ruleId !== null &&
+            strlen($ruleId) >= GiftCardHelper::GIFT_CARD_STRING_LENGTH
         ) {
+            $this->giftyHelper->logger->debug('RuleModelLoad afterLoad');
+
             $code = $this->giftyHelper->sanitizeCouponInput($ruleId);
+
+            if (strlen($code) !== GiftCardHelper::GIFT_CARD_STRING_LENGTH) {
+                return $result;
+            }
+
             $giftCard = $this->giftCardHelper->getGiftCard($code);
 
             if ($giftCard !== null && $giftCard->isRedeemable()) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "gifty/plugin-magento2",
   "description": "Gifty module for accepting Gifty gift cards in your Magento2 shop.",
   "type": "magento2-module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "require": {
     "php": "~7.3.0||~7.4.0||~8.0.0",


### PR DESCRIPTION
This PR adds stricter rules for card recognition so that the Gifty API is less frequently requested.

Previously all discount codes entered during check-out that do not exist locally in the Magento installation would be checked through the Gifty API. In combination with other Magento modules frequently using Sales Rules, this could lead to lots of checkups. That caused a block of the requesting server because of security measures on the Gifty API.

This PR ensures only looking up codes of 16 characters. Also, lookups are shared through the entire lifecycle maximising the requests in a single request to one.